### PR TITLE
Update stats script to generate grants-data.json

### DIFF
--- a/website/update-stats.sh
+++ b/website/update-stats.sh
@@ -8,9 +8,10 @@ cd "$(dirname "$0")/.."
 source venv/bin/activate
 
 # Run stats.py to generate fresh JSON data and save it to the website directory
-python core/stats.py --json > website/public/sample-data.json
+python core/stats.py --json > website/public/grants-data.json
+cp website/public/grants-data.json website/public/sample-data.json
 
-echo "Updated website/public/sample-data.json with the latest statistics"
+echo "Updated website/public/grants-data.json and website/public/sample-data.json with the latest statistics"
 
 # If npm is installed, also build the website
 if command -v npm &> /dev/null; then


### PR DESCRIPTION
## Summary
- Write stats output to `website/public/grants-data.json` and keep `sample-data.json` as a backward-compatible copy

## Testing
- `pytest`
- `bash website/update-stats.sh`
- `python -m http.server 8000 --directory website/public` (manual curl to verify JSON served)


------
https://chatgpt.com/codex/tasks/task_e_6896508483648324a8246c15fa80ab56